### PR TITLE
correction fonction 'ajout article panier' ayant de l'ancien code

### DIFF
--- a/src/app/services/panier/panier.service.ts
+++ b/src/app/services/panier/panier.service.ts
@@ -11,14 +11,7 @@ export class PanierService {
   constructor() { }
 
   verificationLocalStorage() {
-    if (localStorage.length != 0) {
-      //Lecture du localstorage et récupération du panier
-      for (let i = 0; i < localStorage.length; i++) {
-        let clef = localStorage.key(i);
-        let article = JSON.parse(localStorage.getItem(clef));
-        //Stockage des articles dans le panier
-        this.panier.push({ article: article.article, quantite: article.quantite });
-      }
+    if (localStorage.length != 0 && localStorage.getItem("panier") != null){
       return true;
     }
     return false;
@@ -48,6 +41,7 @@ export class PanierService {
       this.panier[0] = { article: articleSupp, quantite: 1 };
     }
     this.enregistrerPanier();//Enregistrement du panier dans le stockage local
+    
   }
 
   enregistrerPanier() {


### PR DESCRIPTION
Normalement, là c'est bon. Il y avait des lignes de codes du tout début, quand on utilisait le localstorage autrement (et mal).